### PR TITLE
feat: add hasura and pgadmin4 to docker-compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ start:
 start-dev:
 	@docker-compose up -d traefik
 	@docker-compose -f docker-compose.workers.yml up -d
-	@docker-compose up -d cross-storage api-v1 api-v2 api-v3 notifications
+	@docker-compose up -d cross-storage api-v1 api-v2 hasura notifications
 	@docker-compose restart traefik
 
 stop:
@@ -63,7 +63,7 @@ frontend-rebuild:
 	@docker-compose exec -T public npm run build
 
 extras:
-	@docker-compose up -d s3 smtp
+	@docker-compose up -d s3 smtp pgadmin4
 
 logs:
 	@docker-compose -f docker-compose.workers.yml -f docker-compose.yml logs -f

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -287,6 +287,7 @@ services:
     - "5007:8080"
     depends_on:
     - pgmaster
+    - api-v2
     restart: always
     environment:
       HASURA_GRAPHQL_DATABASE_URL: postgres://monkey_user:monkey_pass@pgmaster:5432/bonde

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -291,3 +291,9 @@ services:
     environment:
       HASURA_GRAPHQL_DATABASE_URL: postgres://monkey_user:monkey_pass@pgmaster:5432/bonde
       HASURA_GRAPHQL_ENABLE_CONSOLE: "true" # set to "false" to disable console
+    labels:
+      traefik.frontend.rule: Host:hasura.bonde.devel
+      traefik.enable: 'true'
+      traefik.alias: hasura
+      traefik.port: '8080'
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -270,3 +270,24 @@ services:
     - pgmaster
     - smtp
     - redis
+
+  pgadmin4:
+    image: dpage/pgadmin4
+    environment: 
+      PGADMIN_DEFAULT_EMAIL: admin_foo@bar.com
+      PGADMIN_DEFAULT_PASSWORD: foobar!!
+    depends_on:
+      - pgmaster
+    ports: 
+      - 5433:80/tcp
+
+  hasura:
+    image: hasura/graphql-engine:v1.0.0-beta.3
+    ports:
+    - "5007:8080"
+    depends_on:
+    - pgmaster
+    restart: always
+    environment:
+      HASURA_GRAPHQL_DATABASE_URL: postgres://monkey_user:monkey_pass@pgmaster:5432/bonde
+      HASURA_GRAPHQL_ENABLE_CONSOLE: "true" # set to "false" to disable console


### PR DESCRIPTION
### Contexto
Esse PR adiciona o PGADMIN4 e o HASURA ao docker-compose.yml, com o objetivo de facilitar o desenvolvimento em cima da ferramenta.