### PR TITLE
Feature/diesel migrations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ migrate:
 
 seeds:
 	@sleep 10;
-	@docker-compose -f  up -d seeds templates-email
+	@docker-compose up -d seeds templates-email
 
 start:
 	@docker-compose -f docker-compose.workers.yml up -d

--- a/Makefile
+++ b/Makefile
@@ -24,13 +24,14 @@ setup:
 	@docker-compose up -d pgmaster
 
 migrate:
-	@docker-compose exec -T pgmaster psql -Umonkey_user monkey_db -c "create database bonde"
-	@docker-compose -f docker-compose.workers.yml pull migrations
-	@docker-compose -f docker-compose.workers.yml up -d migrations templates-email
+	@docker-compose exec -T pgmaster psql -Umonkey_user monkey_db -c "create database bonde;"
+	@docker-compose exec -T pgmaster psql -Umonkey_user monkey_db -c "create role postgraphql login password '3x4mpl3'; create role anonymous; create role common_user; create role admin; create role postgres; create role microservices;"
+	@docker-compose build migrations
+	@docker-compose up -d migrations
 
 seeds:
 	@sleep 10;
-	@docker-compose -f docker-compose.workers.yml up -d seeds
+	@docker-compose -f  up -d seeds templates-email
 
 start:
 	@docker-compose -f docker-compose.workers.yml up -d

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ mkdir bonde
 cd bonde
 git clone git@github.com:nossas/bonde-install.git
 cd bonde-install
-make begin
+make setup
+make migrate
 ```
 
 **Important**: In case of problems when running make begin run make clean and try again
@@ -57,6 +58,7 @@ These are essentials URLs from BONDE and must be accessible to get local copy fu
 * 2-save-the-whales.bonde.devel
 * 3-vamos-limpar-o-tiete.bonde.devel
 * teste.bonde.devel
+* pgadmin.bonde.devel
 
 If you want to test mail and s3 integrations used by our modules, you should run:
 
@@ -65,6 +67,13 @@ If you want to test mail and s3 integrations used by our modules, you should run
 * fake-s3.bonde.devel
 * fake-smtp.bonde.devel
 * traefik.bonde.devel
+
+### Migrations
+
+Commands to create new:
+
+```docker-compose run --rm migrations diesel migration generate initial_chatbot```
+
 
 ### Dispatchers
 

--- a/docker-compose.common.yml
+++ b/docker-compose.common.yml
@@ -69,7 +69,7 @@ services:
       traefik.port: '8080'
       traefik.enable: 'true'
   pgmaster:
-    image: postgres:9
+    image: postgres:10
     environment:
       POSTGRES_DB: monkey_db
       POSTGRES_PASSWORD: monkey_pass

--- a/docker-compose.workers.yml
+++ b/docker-compose.workers.yml
@@ -10,8 +10,8 @@ version: '2'
 services:
 
   migrations:
-    image: nossas/bonde-server:develop
-    # build: ./../bonde-server
+    image: nossas/bonde-migrations:develop
+    # build: ./../bonde-migrations
     environment:
       AWS_ACCESS_KEY_ID: admin
       AWS_BUCKET: bonde
@@ -48,38 +48,14 @@ services:
       WEB_MEMORY: '256'
     # volumes:
     # - ./../bonde-server:/usr/app
-    external_links:
-    - pgmaster
-    - redis
     command:
-    - bundle
-    - exec
-    - rake
-    - db:migrate
+    - diesel
+    - migration
+    - run
     labels:
       io.rancher.container.start_once: 'true'
     # networks:
     #   bonde:
-
-  seeds:
-    extends:
-      service: migrations
-    command: ["bundle", "exec", "rake", "db:seed"]
-
-  mailchimp:
-    extends:
-      service: migrations
-    command: ["bundle", "exec", "sidekiq", "-c", "5", "-q", "mailchimp_synchro"]
-
-  mailers:
-    extends:
-      service: migrations
-    command: ["bundle", "exec", "sidekiq", "-q", "default", "-q", "mailers", "-c", "5"]
-
-  templates-email:
-    extends:
-      service: migrations
-    command: ["bundle", "exec", "rake", "notifications:all"]
 
   bot-worker:
     image: nossas/bonde-bot:develop

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,16 @@ services:
       file: docker-compose.common.yml
       service: assets-images
 
+  migrations:
+    extends:
+      file: docker-compose.workers.yml
+      service: migrations
+    depends_on:
+    - pgmaster
+    environment:
+      DATABASE_URL: postgres://monkey_user:monkey_pass@pgmaster/bonde
+    volumes:
+    - ./../bonde-migrations/:/volumes
   bot:
     image: nossas/bonde-bot:develop
     environment:
@@ -179,9 +189,9 @@ services:
     # - common/pgpool:pgpool
     # - common/redis:redis
     # - common/smtp:smtp
-    depends_on:
-    - pgmaster
-    - redis
+    # depends_on:
+    # - pgmaster
+    # - redis
     command:
     - bundle
     - exec
@@ -273,13 +283,17 @@ services:
 
   pgadmin4:
     image: dpage/pgadmin4
-    environment: 
+    environment:
       PGADMIN_DEFAULT_EMAIL: admin_foo@bar.com
       PGADMIN_DEFAULT_PASSWORD: foobar!!
     depends_on:
       - pgmaster
-    ports: 
+    ports:
       - 5433:80/tcp
+    labels:
+      traefik.frontend.rule: Host:pgadmin.bonde.devel
+      traefik.enable: 'true'
+      traefik.port: '80'
 
   hasura:
     image: hasura/graphql-engine:v1.0.0-beta.3
@@ -298,3 +312,22 @@ services:
       traefik.alias: hasura
       traefik.port: '8080'
 
+  seeds:
+    extends:
+      service: api-v1
+    command: ["bundle", "exec", "rake", "db:seed"]
+
+  mailchimp:
+    extends:
+      service: api-v1
+    command: ["bundle", "exec", "sidekiq", "-c", "5", "-q", "mailchimp_synchro"]
+
+  mailers:
+    extends:
+      service: api-v1
+    command: ["bundle", "exec", "sidekiq", "-q", "default", "-q", "mailers", "-c", "5"]
+
+  templates-email:
+    extends:
+      service: api-v1
+    command: ["bundle", "exec", "rake", "notifications:all"]


### PR DESCRIPTION
Update install to be able to work with new bonde migrations

How to test:

Run:

```make setup``` 2x
```make migrate```1x

After that check logs:

```docker-compose logs migrations```

We should see:

```
lpirola@lpirola-MacBookPro:~/code/nossas/bonde-install$ docker-compose down -v
Stopping bonde-install_pgmaster_1 ... done
Removing bonde-install_migrations_1                   ... done
Removing bonde-install_pgmaster_1                     ... done
Removing bonde-install_templates-email_1              ... done
Removing 7c0fd9478b9d_bonde-install_templates-email_1 ... done
Removing bonde-install_mailers_1                      ... done
Removing bonde-install_mailchimp_1                    ... done
Removing bonde-install_seeds_1                        ... done
Removing network bonde-install_default
Removing volume bonde-install_redis_data
Removing volume bonde-install_s3_data
Removing volume bonde-install_pgmaster_data
lpirola@lpirola-MacBookPro:~/code/nossas/bonde-install$ make setup
Creating network "bonde-install_default" with the default driver
Creating volume "bonde-install_redis_data" with local driver
Creating volume "bonde-install_s3_data" with local driver
Creating volume "bonde-install_pgmaster_data" with local driver
Creating bonde-install_pgmaster_1 ... done
lpirola@lpirola-MacBookPro:~/code/nossas/bonde-install$ make setup
Starting bonde-install_pgmaster_1 ... done
lpirola@lpirola-MacBookPro:~/code/nossas/bonde-install$ make migrate
CREATE DATABASE
CREATE ROLE
migrations uses an image, skipping
bonde-install_pgmaster_1 is up-to-date
Creating bonde-install_migrations_1 ... done
lpirola@lpirola-MacBookPro:~/code/nossas/bonde-install$ docker-compose logs migrations
Attaching to bonde-install_migrations_1
migrations_1       | Running migration 2018-07-31-182711_initial
migrations_1       | Running migration 2019-07-31-210829_initial_chatbot
```