### PR TITLE
chore(remote-schema): Add to accounts-local default domain;

### DIFF
--- a/remote-schemas/docker-compose.yml
+++ b/remote-schemas/docker-compose.yml
@@ -169,6 +169,7 @@ services:
       LOG_LEVEL: debug
       PORT: '4001'
       NODE_ENV: 'development'
+      APP_DOMAIN: '.bonde.devel'
     command:
       - pnpm
       - m


### PR DESCRIPTION
Definindo valor padrão para utilizar no ambiente local ao gerar o cookie utilizando o serviço de autenticação em outro ambiente.