### PR TITLE
Certificado Automatizado + Melhorias de segurança

### DIFF
--- a/clients/docker-compose.yml
+++ b/clients/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   accounts:
-    image: ${DOCKER_IMAGE:-nossas/bonde-clients:v7.0.8}
+    image: ${DOCKER_IMAGE:-nossas/bonde-clients:v7.0.9}
     command: yarn pnpm --filter accounts-client start
     restart: "${DOCKER_RESTART_POLICY:-unless-stopped}"
     pull_policy: always
@@ -17,7 +17,7 @@ services:
       traefik.http.routers.accounts.tls.certresolver: myresolver
 
   app:
-    image: ${DOCKER_IMAGE:-nossas/bonde-clients:v7.0.8}
+    image: ${DOCKER_IMAGE:-nossas/bonde-clients:v7.0.9}
     command: yarn pnpm --filter admin-client start
     restart: "${DOCKER_RESTART_POLICY:-unless-stopped}"
     pull_policy: always
@@ -35,7 +35,7 @@ services:
       traefik.http.routers.app.tls.certresolver: myresolver
 
   admin-canary:
-    image: ${DOCKER_IMAGE:-nossas/bonde-clients:v7.0.8}
+    image: ${DOCKER_IMAGE:-nossas/bonde-clients:v7.0.9}
     command: yarn pnpm --filter canary-client start
     restart: "${DOCKER_RESTART_POLICY:-unless-stopped}"
     pull_policy: always
@@ -52,7 +52,7 @@ services:
       traefik.http.routers.admin-canary.tls.certresolver: myresolver
 
   redes:
-    image: ${DOCKER_IMAGE:-nossas/bonde-clients:v7.0.8}
+    image: ${DOCKER_IMAGE:-nossas/bonde-clients:v7.0.9}
     command: yarn pnpm --filter redes-client start
     restart: "${DOCKER_RESTART_POLICY:-unless-stopped}"
     pull_policy: always
@@ -69,7 +69,7 @@ services:
       traefik.http.routers.redes.tls.certresolver: myresolver
 
   public:
-    image: ${DOCKER_IMAGE:-nossas/bonde-clients:v7.0.8}
+    image: ${DOCKER_IMAGE:-nossas/bonde-clients:v7.0.9}
     command: yarn pnpm --filter webpage-client start
     restart: "${DOCKER_RESTART_POLICY:-unless-stopped}"
     pull_policy: always

--- a/common/docker-compose.yml
+++ b/common/docker-compose.yml
@@ -78,7 +78,7 @@ services:
       - traefik.http.routers.traefik.tls=true
       - traefik.http.routers.traefik.tls.certresolver=myresolver
       - traefik.http.routers.traefik.middlewares=test-auth
-      - traefik.http.middlewares.test-auth.basicauth.users=${DEFAULT_TRAEFIK_USER:-test:$$apr1$$H6uskkkW$$IgXLP6ewTrSuBkTrqE8wj/,test2:$$apr1$$d9hr9HBB$$4HxwgUir3HP4EsggP/QNo0}"
+      - "traefik.http.middlewares.test-auth.basicauth.users=${DEFAULT_TRAEFIK_USER:-cobrador:$$apr1$$4YfBuKHl$$jyPbiBJLOH7C5CzHFE4G10}"
 
   etcd:
     image: 'bitnami/etcd:latest'

--- a/common/docker-compose.yml
+++ b/common/docker-compose.yml
@@ -1,11 +1,3 @@
-
-x-variables:
-    flag_initial_cluster_token: &flag_initial_cluster_token '--initial-cluster-token=mys3cr3ttok3n'
-    common_settings: &common_settings
-        image: quay.io/coreos/etcd:v3.5.2
-        entrypoint: /usr/local/bin/etcd
-        ports:
-            - 2379
 # This script is meant for quick & easy install via:
 #   $ curl -fsSL https://get.docker.com -o get-docker.sh
 #   $ sh get-docker.sh
@@ -14,7 +6,7 @@ services:
   traefik:
     image: "traefik:v2.6"
     depends_on:
-      - etcd-1
+      - etcd
     command:
       - "--accesslog.filepath=/logs/access.log"
       - "--accesslog.format=json"
@@ -34,7 +26,7 @@ services:
       - "--providers.docker.exposedbydefault=false"
       - "--providers.docker.defaultRule=Host(`{{ index .Labels \"com.docker.compose.service\"}}.${DEFAULT_DOMAIN_RULE:-bonde.devel}`)"
       - "--providers.etcd=true"
-      - "--providers.etcd.endpoints=etcd-1:2379"
+      - "--providers.etcd.endpoints=etcd:2379"
       - "--providers.etcd.rootkey=traefik"
       - "--entrypoints.web.address=:80"
       - "--entrypoints.web.http.redirections.entryPoint.to=websecure"
@@ -88,53 +80,16 @@ services:
       - traefik.http.routers.traefik.middlewares=test-auth
       - traefik.http.middlewares.test-auth.basicauth.users=${DEFAULT_TRAEFIK_USER:-test:$$apr1$$H6uskkkW$$IgXLP6ewTrSuBkTrqE8wj/,test2:$$apr1$$d9hr9HBB$$4HxwgUir3HP4EsggP/QNo0}"
 
-  etcd-1:
-    <<: *common_settings
-    command:
-      - '--name=etcd-1'
-      - '--initial-advertise-peer-urls=http://etcd-1:2380'
-      - '--listen-peer-urls=http://0.0.0.0:2380'
-      - '--listen-client-urls=http://0.0.0.0:2379'
-      - '--advertise-client-urls=http://etcd-1:2379'
-      - '--heartbeat-interval=250'
-      - '--election-timeout=1250'
-      - '--initial-cluster=etcd-1=http://etcd-1:2380,etcd-2=http://etcd-2:2380,etcd-3=http://etcd-3:2380'
-      - '--initial-cluster-state=new'
-      - *flag_initial_cluster_token
+  etcd:
+    image: 'bitnami/etcd:latest'
+    environment:
+      - ALLOW_NONE_AUTHENTICATION=yes
+      - ETCD_ADVERTISE_CLIENT_URLS=http://etcd:2379
     volumes:
-      - etcd1:/etcd_data
-
-  etcd-2:
-    <<: *common_settings
-    command:
-      - '--name=etcd-2'
-      - '--initial-advertise-peer-urls=http://etcd-2:2380'
-      - '--listen-peer-urls=http://0.0.0.0:2380'
-      - '--listen-client-urls=http://0.0.0.0:2379'
-      - '--advertise-client-urls=http://etcd-2:2379'
-      - '--heartbeat-interval=250'
-      - '--election-timeout=1250'
-      - '--initial-cluster=etcd-1=http://etcd-1:2380,etcd-2=http://etcd-2:2380,etcd-3=http://etcd-3:2380'
-      - '--initial-cluster-state=new'
-      - *flag_initial_cluster_token
-    volumes:
-      - etcd2:/etcd_data
-
-  etcd-3:
-    <<: *common_settings
-    command:
-      - '--name=etcd-3'
-      - '--initial-advertise-peer-urls=http://etcd-3:2380'
-      - '--listen-peer-urls=http://0.0.0.0:2380'
-      - '--listen-client-urls=http://0.0.0.0:2379'
-      - '--advertise-client-urls=http://etcd-3:2379'
-      - '--heartbeat-interval=250'
-      - '--election-timeout=1250'
-      - '--initial-cluster=etcd-1=http://etcd-1:2380,etcd-2=http://etcd-2:2380,etcd-3=http://etcd-3:2380'
-      - '--initial-cluster-state=new'
-      - *flag_initial_cluster_token
-    volumes:
-      - etcd3:/etcd_data
+      - etcd_data:/bitnami/etcd
+    ports:
+      - 2379:2379
+      - 2380:2380
 
   redis:
     image: redislabs/redismod
@@ -198,12 +153,9 @@ volumes:
     driver: local
   letsencrypt:
     driver: local
-  etcd1:
+  etcd_data:
     driver: local
-  etcd2:
-    driver: local
-  etcd3:
-    driver: local
+
 networks:
   default:
     name: bonde

--- a/common/docker-compose.yml
+++ b/common/docker-compose.yml
@@ -33,6 +33,10 @@ services:
       - "--entrypoints.web.http.redirections.entryPoint.scheme=https"
       - "--entrypoints.web.http.redirections.entrypoint.permanent=true"
       - "--entrypoints.websecure.address=:443"
+      # - "--entrypoints.websecure.http.tls=true"
+      # - "--entrypoints.websecure.http.tls.options=default@etcd"
+      - "--entrypoints.websecure.http.middlewares=securityHeader@etcd"
+
       - "--certificatesresolvers.myresolver.acme.tlschallenge=true"
       #- "--certificatesresolvers.myresolver.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory"
       - "--certificatesresolvers.myresolver.acme.email=${DEFAULT_EMAIL_ACME:-tech@bonde.devel}"
@@ -73,6 +77,9 @@ services:
       - traefik.http.services.traefik.loadbalancer.server.port=8080
       - traefik.http.routers.traefik.tls=true
       - traefik.http.routers.traefik.tls.certresolver=myresolver
+      # - "traefik.http.routers.wwwsecure-catchall.middlewares=wwwtohttps"
+      - traefik.http.middlewares.test-auth.basicauth.users=${DEFAULT_TRAEFIK_USER:-test:$$apr1$$H6uskkkW$$IgXLP6ewTrSuBkTrqE8wj/,test2:$$apr1$$d9hr9HBB$$4HxwgUir3HP4EsggP/QNo0}"
+      
 
   etcd:
     image: 'bitnami/etcd:latest'

--- a/common/docker-compose.yml
+++ b/common/docker-compose.yml
@@ -77,8 +77,8 @@ services:
       - traefik.http.services.traefik.loadbalancer.server.port=8080
       - traefik.http.routers.traefik.tls=true
       - traefik.http.routers.traefik.tls.certresolver=myresolver
-      - traefik.http.routers.traefik.middlewares=test-auth
-      - "traefik.http.middlewares.test-auth.basicauth.users=${DEFAULT_TRAEFIK_USER:-cobrador:$$apr1$$4YfBuKHl$$jyPbiBJLOH7C5CzHFE4G10}"
+      # - traefik.http.routers.traefik.middlewares=test-auth
+      # - "traefik.http.middlewares.test-auth.basicauth.users=${DEFAULT_TRAEFIK_USER:-cobrador:$$apr1$$4YfBuKHl$$jyPbiBJLOH7C5CzHFE4G10}"
 
   etcd:
     image: 'bitnami/etcd:latest'

--- a/common/docker-compose.yml
+++ b/common/docker-compose.yml
@@ -1,3 +1,11 @@
+
+x-variables:
+    flag_initial_cluster_token: &flag_initial_cluster_token '--initial-cluster-token=mys3cr3ttok3n'
+    common_settings: &common_settings
+        image: quay.io/coreos/etcd:v3.5.2
+        entrypoint: /usr/local/bin/etcd
+        ports:
+            - 2379
 # This script is meant for quick & easy install via:
 #   $ curl -fsSL https://get.docker.com -o get-docker.sh
 #   $ sh get-docker.sh
@@ -6,7 +14,7 @@ services:
   traefik:
     image: "traefik:v2.6"
     depends_on:
-      - etcd
+      - etcd-1
     command:
       - "--accesslog.filepath=/logs/access.log"
       - "--accesslog.format=json"
@@ -26,7 +34,7 @@ services:
       - "--providers.docker.exposedbydefault=false"
       - "--providers.docker.defaultRule=Host(`{{ index .Labels \"com.docker.compose.service\"}}.${DEFAULT_DOMAIN_RULE:-bonde.devel}`)"
       - "--providers.etcd=true"
-      - "--providers.etcd.endpoints=etcd:2379"
+      - "--providers.etcd.endpoints=etcd-1:2379"
       - "--providers.etcd.rootkey=traefik"
       - "--entrypoints.web.address=:80"
       - "--entrypoints.web.http.redirections.entryPoint.to=websecure"
@@ -63,32 +71,70 @@ services:
       - traefik.enable=true
 
       # global redirection: https (www.) to https
-      - "traefik.http.routers.wwwsecure-catchall.rule=HostRegexp(`{host:(www\\.).+}`)"
-      - "traefik.http.routers.wwwsecure-catchall.entrypoints=websecure"
-      - "traefik.http.routers.wwwsecure-catchall.tls=true"
-      - "traefik.http.routers.wwwsecure-catchall.middlewares=wwwtohttps"
+      - traefik.http.routers.wwwsecure-catchall.rule=HostRegexp(`{host:(www\\.).+}`)
+      - traefik.http.routers.wwwsecure-catchall.entrypoints=websecure
+      - traefik.http.routers.wwwsecure-catchall.tls=true
+      - traefik.http.routers.wwwsecure-catchall.middlewares=wwwtohttps
 
       # middleware: http(s)://(www.) to  https://
-      - "traefik.http.middlewares.wwwtohttps.redirectregex.regex=^https?://(?:www\\.)?(.+)"
-      - "traefik.http.middlewares.wwwtohttps.redirectregex.replacement=https://$${1}"
-      - "traefik.http.middlewares.wwwtohttps.redirectregex.permanent=true"
+      - traefik.http.middlewares.wwwtohttps.redirectregex.regex=^https?://(?:www\\.)?(.+)
+      - traefik.http.middlewares.wwwtohttps.redirectregex.replacement=https://$${1}
+      - traefik.http.middlewares.wwwtohttps.redirectregex.permanent=true
 
       # export traefik dashboard
       - traefik.http.services.traefik.loadbalancer.server.port=8080
       - traefik.http.routers.traefik.tls=true
       - traefik.http.routers.traefik.tls.certresolver=myresolver
-      # - "traefik.http.routers.wwwsecure-catchall.middlewares=wwwtohttps"
+      - traefik.http.routers.traefik.middlewares=test-auth
       - traefik.http.middlewares.test-auth.basicauth.users=${DEFAULT_TRAEFIK_USER:-test:$$apr1$$H6uskkkW$$IgXLP6ewTrSuBkTrqE8wj/,test2:$$apr1$$d9hr9HBB$$4HxwgUir3HP4EsggP/QNo0}"
-      
 
-  etcd:
-    image: 'bitnami/etcd:latest'
-    environment:
-      - ALLOW_NONE_AUTHENTICATION=yes
-      - ETCD_ADVERTISE_CLIENT_URLS=http://etcd:2379
-    ports:
-      - 2379:2379
-      - 2380:2380
+  etcd-1:
+    <<: *common_settings
+    command:
+      - '--name=etcd-1'
+      - '--initial-advertise-peer-urls=http://etcd-1:2380'
+      - '--listen-peer-urls=http://0.0.0.0:2380'
+      - '--listen-client-urls=http://0.0.0.0:2379'
+      - '--advertise-client-urls=http://etcd-1:2379'
+      - '--heartbeat-interval=250'
+      - '--election-timeout=1250'
+      - '--initial-cluster=etcd-1=http://etcd-1:2380,etcd-2=http://etcd-2:2380,etcd-3=http://etcd-3:2380'
+      - '--initial-cluster-state=new'
+      - *flag_initial_cluster_token
+    volumes:
+      - etcd1:/etcd_data
+
+  etcd-2:
+    <<: *common_settings
+    command:
+      - '--name=etcd-2'
+      - '--initial-advertise-peer-urls=http://etcd-2:2380'
+      - '--listen-peer-urls=http://0.0.0.0:2380'
+      - '--listen-client-urls=http://0.0.0.0:2379'
+      - '--advertise-client-urls=http://etcd-2:2379'
+      - '--heartbeat-interval=250'
+      - '--election-timeout=1250'
+      - '--initial-cluster=etcd-1=http://etcd-1:2380,etcd-2=http://etcd-2:2380,etcd-3=http://etcd-3:2380'
+      - '--initial-cluster-state=new'
+      - *flag_initial_cluster_token
+    volumes:
+      - etcd2:/etcd_data
+
+  etcd-3:
+    <<: *common_settings
+    command:
+      - '--name=etcd-3'
+      - '--initial-advertise-peer-urls=http://etcd-3:2380'
+      - '--listen-peer-urls=http://0.0.0.0:2380'
+      - '--listen-client-urls=http://0.0.0.0:2379'
+      - '--advertise-client-urls=http://etcd-3:2379'
+      - '--heartbeat-interval=250'
+      - '--election-timeout=1250'
+      - '--initial-cluster=etcd-1=http://etcd-1:2380,etcd-2=http://etcd-2:2380,etcd-3=http://etcd-3:2380'
+      - '--initial-cluster-state=new'
+      - *flag_initial_cluster_token
+    volumes:
+      - etcd3:/etcd_data
 
   redis:
     image: redislabs/redismod
@@ -152,7 +198,12 @@ volumes:
     driver: local
   letsencrypt:
     driver: local
-
+  etcd1:
+    driver: local
+  etcd2:
+    driver: local
+  etcd3:
+    driver: local
 networks:
   default:
     name: bonde


### PR DESCRIPTION
## Contexto
<!-- Qual problema está tentando resolver? -->
Com nova estrutura de certificado automatizado, houve uma necessidade de mudar a configuração de domínio por parte da Mobilização, que chamamos de Domínio Customizado, ao salvar uma configuração de domínio customizado, seja ela subdomínio, domínio principal ou domínio externo a aplicação deve garantir o processo de certificação daquele endereço web.

## Checklist
- [x] Melhorias de segurança
- [x] Persistência do bando de dados chave valor
- [x] https://github.com/nossas/bonde-clients/pull/1597
- [x] https://github.com/nossas/bonde-apis/pull/44

## Notas de deploy
Os seguintes registros precisam estar presentes no banco de dados de chave valor utilizado para carregar as configurações dinâmicas:

```
etcdctl put traefik/tls/options/default/minVersion VersionTLS12
etcdctl put traefik/tls/options/default/cipherSuites/0 TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
etcdctl put traefik/tls/options/default/cipherSuites/1 TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
etcdctl put traefik/tls/options/default/cipherSuites/2 TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
etcdctl put traefik/tls/options/default/cipherSuites/3 TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
etcdctl put traefik/tls/options/default/cipherSuites/4 TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
etcdctl put traefik/tls/options/default/cipherSuites/5 TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
```


```
etcdctl put traefik/http/middlewares/securityHeader/headers/sslredirect true
etcdctl put traefik/http/middlewares/securityHeader/headers/framedeny true
etcdctl put traefik/http/middlewares/securityHeader/headers/stsincludesubdomains true
etcdctl put traefik/http/middlewares/securityHeader/headers/stspreload true
etcdctl put traefik/http/middlewares/securityHeader/headers/stsseconds 63072000
etcdctl put traefik/http/middlewares/securityHeader/headers/contenttypenosniff true
```

Comando para gerar senha de autenticação básica:

```
echo $(htpasswd -nb dev senhadificil) | sed -e s/\\$/\\$\\$/g
```

## Como testar?
<!-- Adicione algumas instruções de como os reviewers podem testar esse PR. -->

Acessando a aba de Domínio da configuração de Mobilização, o usuário deve ser capaz de:

- Criar Domínio Externo;
- Criar subdomínio;
- Criar domínio principal;

Para domínios que já foram propagados, deve ser instantâneo a configuração de domínio e subdominio.