### PR TITLE
chore(common): update n8n image to version 0.202.1

### DIFF
--- a/common/docker-compose.yml
+++ b/common/docker-compose.yml
@@ -113,7 +113,7 @@ services:
       - traefik.http.routers.redisinsight.tls.certresolver=myresolver
  
   n8n:
-    image: n8nio/n8n:latest
+    image: n8nio/n8n:0.202.1
     depends_on:
       - postgres
     environment:


### PR DESCRIPTION
Como tá um bug no graphql do n8n da ultima versão alterar a versão para a utilizada em staging 0.202.1